### PR TITLE
feat: support nested sso

### DIFF
--- a/src/ziti-browzer-sw.ts
+++ b/src/ziti-browzer-sw.ts
@@ -112,7 +112,9 @@ const matchGETCb = (url:any, request:any) => {
   if (typeof self._zitiConfig === 'undefined') {
     return true;
   }
-  if (getURL.searchParams.get("code") && getURL.searchParams.get("state")) {
+
+  if (getURL.searchParams.get("code") && getURL.searchParams.get("state") &&
+      getURL.pathname !== self._zitiConfig.idp.nested_sso_inner_cb_path) {
     return false;
   }
   let controllerURL = new URL(self._zitiConfig.controller.api);


### PR DESCRIPTION
This modification is for supporting upstream's app can run OIDC authentication flow.

Sharing the same OIDC SSO between Browzer and upstream's app can also achieve single sign on, which improves the user's experience.